### PR TITLE
PostgreSQL: Added fileExecution method

### DIFF
--- a/Sources/Flux/DB/SQL/Core/Connection.swift
+++ b/Sources/Flux/DB/SQL/Core/Connection.swift
@@ -64,6 +64,8 @@ public protocol Connection {
     
     func execute(statement: String, parameters: [QueryParameterConvertible]) throws -> ResultType
     
+    func executeFromFile(atPath path: String) throws -> ResultType
+    
     func begin() throws
     
     func commit() throws

--- a/Sources/Flux/MySQL/MySQLConnection.swift
+++ b/Sources/Flux/MySQL/MySQLConnection.swift
@@ -205,6 +205,28 @@ public class MySQLConnection: Connection {
         return MySQLResult(result)
     }
     
+    public func executeFromFile(atPath path: String) throws -> MySQLResult {
+        let file = try File(path: path, mode: .Read)
+        let data = try file.read()
+        let statement = try String(data: data)
+        
+        guard mysql_real_query(connection, statement, UInt(statement.utf8.count)) == 0 else {
+            throw statusError
+        }
+        
+        let result = mysql_store_result(connection)
+        
+        guard result != nil else {
+            guard mysql_field_count(connection) == 0 else {
+                throw Error.BadResult
+            }
+            
+            return MySQLResult(nil)
+        }
+        
+        return MySQLResult(result)
+    }
+    
     public func createSavePointNamed(name: String) throws {
         try execute("SAVEPOINT \(name)")
     }

--- a/Sources/Flux/MySQL/MySQLConnection.swift
+++ b/Sources/Flux/MySQL/MySQLConnection.swift
@@ -209,22 +209,8 @@ public class MySQLConnection: Connection {
         let file = try File(path: path, mode: .Read)
         let data = try file.read()
         let statement = try String(data: data)
-        
-        guard mysql_real_query(connection, statement, UInt(statement.utf8.count)) == 0 else {
-            throw statusError
-        }
-        
-        let result = mysql_store_result(connection)
-        
-        guard result != nil else {
-            guard mysql_field_count(connection) == 0 else {
-                throw Error.BadResult
-            }
-            
-            return MySQLResult(nil)
-        }
-        
-        return MySQLResult(result)
+       
+        return try execute(statement)
     }
     
     public func createSavePointNamed(name: String) throws {

--- a/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
@@ -220,7 +220,7 @@ public class PostgreSQLConnection: Connection {
     
     /**
      Execute a request stored in the file. 
-     Notice that it execute a non-parameterized request.
+     Notice that it executes a non-parameterized request.
      
      - parameter path: the path to the input file.
     

--- a/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
@@ -224,11 +224,11 @@ public class PostgreSQLConnection: Connection {
      
      - parameter path: the path to the input file.
     
-     - throws: the call can throw either an error caused but the reading of the file or a PostgreSQLResult.Error.BadStatus error
+     - throws: the call can throw either an error caused by the reading of the file or a PostgreSQLResult.Error.BadStatus error
     
      - returns: returns a PostgreSQLResult
      */
-    public func fileExecute(path: String) throws -> PostgreSQLResult {
+    public func executeFromFile(atPath path: String) throws -> PostgreSQLResult {
         
         let file = try File(path: path, mode: .Read)
         let data = try file.read()

--- a/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
+++ b/Sources/Flux/PostgreSQL/PostgreSQLConnection.swift
@@ -217,4 +217,28 @@ public class PostgreSQLConnection: Connection {
             )
         )
     }
+    
+    /**
+     Execute a request stored in the file. 
+     Notice that it execute a non-parameterized request.
+     
+     - parameter path: the path to the input file.
+    
+     - throws: the call can throw either an error caused but the reading of the file or a PostgreSQLResult.Error.BadStatus error
+    
+     - returns: returns a PostgreSQLResult
+     */
+    public func fileExecute(path: String) throws -> PostgreSQLResult {
+        
+        let file = try File(path: path, mode: .Read)
+        let data = try file.read()
+        let statement = try String(data: data)
+        
+        
+        return try PostgreSQLResult(
+            PQexec(connection,
+                statement
+            )
+        )
+    }
 }


### PR DESCRIPTION
The method is useful to execute batch requests, thing which is not possible elsewhere because parameterized executions allows only one request at the time.

I also did the modification on the regular Zewo/PostgreSQL, I can submit a PR too if needed.